### PR TITLE
feat(programme): afficher le libellé du niveau à côté de l'icône

### DIFF
--- a/src/routes/programme/Event.svelte
+++ b/src/routes/programme/Event.svelte
@@ -75,6 +75,7 @@
 			{#if 'level' in props && props.level}
 				<span class="level" title={props.level} aria-label="Niveau {props.level}">
 					<LevelIcon level={props.level} />
+					{props.level}
 				</span>
 			{/if}
 			<span class="event-type">{event_type}</span>
@@ -143,12 +144,16 @@
 	}
 
 	.level {
-		height: 26px;
-		display: flex;
-
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
 		background-color: hsla(var(--accent-color), 0.1);
-		padding: 4px;
+		padding: 4px 8px 4px 6px;
 		border-radius: 12px;
+		font-size: 0.75rem;
+		font-weight: 500;
+		color: hsla(var(--accent-color), 1);
+		line-height: 1;
 	}
 
 	.speakers {

--- a/src/routes/programme/session/[slug]/+page.svelte
+++ b/src/routes/programme/session/[slug]/+page.svelte
@@ -10,6 +10,7 @@
 		formatTime,
 		getThreeFollowingSessionsWithTheSameTheme
 	} from '../../utils';
+	import LevelIcon from '../../LevelIcon.svelte';
 	import FutureSessions from './FutureSessions.svelte';
 	import { addToGoogleCalendar, downloadIcsFile, share } from './share.utils';
 
@@ -34,6 +35,12 @@
 					</li>
 				{/if}
 				<li class="format" aria-label="Format : {data.format}">{data.format}</li>
+				{#if data.level}
+					<li class="level" aria-label="Niveau : {data.level}">
+						<LevelIcon level={data.level} />
+						{data.level}
+					</li>
+				{/if}
 				<li class="duration" aria-label="duration : {duration}">{duration}</li>
 			</ul>
 
@@ -156,6 +163,19 @@
 
 	ul.infos-utiles-one li.duration {
 		color: #6b7280;
+	}
+
+	ul.infos-utiles-one li.level {
+		display: inline-flex;
+		align-items: center;
+		gap: 4px;
+		background-color: hsla(var(--accent-color), 0.1);
+		padding: 4px 8px 4px 6px;
+		border-radius: 12px;
+		font-size: 0.75rem;
+		font-weight: 500;
+		color: hsla(var(--accent-color), 1);
+		line-height: 1;
 	}
 
 	h1 {


### PR DESCRIPTION
Affiche le texte du niveau (Introduction, Standard, Avancé) à côté de l'icône dans deux endroits :

  - Programme (Event.svelte) : le libellé apparaît dans le badge niveau sur chaque talk de la grille
  - Détail d'un talk (session/[slug]/+page.svelte) : le badge niveau est ajouté dans la barre d'infos en haut de la page

  Le badge icône + texte est stylisé de manière cohérente aux deux endroits : fond coloré à l'accent, border-radius, police petite et semi-bold.
<img width="1396" height="547" alt="image" src="https://github.com/user-attachments/assets/18b806f9-4cf6-48cc-aa85-c6143e0152b2" />
<img width="321" height="843" alt="image" src="https://github.com/user-attachments/assets/692734b6-7d51-4c20-a43c-4531dcd123e5" />

<img width="1357" height="677" alt="image" src="https://github.com/user-attachments/assets/14264725-5e5c-4c4b-8508-479257d2759f" />
